### PR TITLE
Fix: Add items to array before adding it to the final output dict

### DIFF
--- a/gnome_keyring_import_export.py
+++ b/gnome_keyring_import_export.py
@@ -189,9 +189,11 @@ def get_gnome_keyrings():
 
         for _item in _collection.get_items():
             if _item is not None:
-                _keyring_items.append(get_item(_item)  )
-
-        _keyrings[_collection_name] = _keyring_items
+                _keyring_items.append(get_item(_item))
+        if _collection_name not in _keyrings:
+            _keyrings[_collection_name] = _keyring_items
+        else:
+            _keyrings["{0}_dupe".format(_collection_name)] = _keyring_items
 
         print(_collection_name + "\n" + str(_keyring_items))
 

--- a/gnome_keyring_import_export.py
+++ b/gnome_keyring_import_export.py
@@ -256,7 +256,7 @@ def fix_attributes(d):
 
 def import_keyrings(from_file):
     with open(from_file, "r") as f:
-        keyrings = json.loads(f)
+        keyrings = json.loads(f.read())
 
     for keyring_name, keyring_items in list(keyrings.items()):
         try:

--- a/gnome_keyring_import_export.py
+++ b/gnome_keyring_import_export.py
@@ -186,11 +186,12 @@ def get_gnome_keyrings():
 
         _collection_name = _collection.get_name()
         _keyring_items = []
-        _keyrings[_collection_name] = _keyring_items
 
         for _item in _collection.get_items():
             if _item is not None:
                 _keyring_items.append(get_item(_item)  )
+
+        _keyrings[_collection_name] = _keyring_items
 
         print(_collection_name + "\n" + str(_keyring_items))
 


### PR DESCRIPTION
With the current implementation the output log prints the found values but the file will never contain them since the array `_keyring_items` is added before it contains values.
This PR simply fixes this so the export file contains the values.